### PR TITLE
[NF-20097] Fix recursive optional properties

### DIFF
--- a/lib/prmd/link.rb
+++ b/lib/prmd/link.rb
@@ -3,7 +3,7 @@ require 'ostruct'
 module Prmd
   class Link
     def initialize(link_schema)
-      @link_schema = link_schema 
+      @link_schema = link_schema
     end
 
     def required_and_optional_parameters
@@ -20,7 +20,7 @@ module Prmd
       schema.properties.keys.each do |prop_name|
         prop = schema.properties[prop_name]
         pref = "#{prefix}#{prop_name}"
-        required = parent_required || schema.property_is_required?(prop_name)
+        required = schema.property_is_required?(prop_name)
 
         handle_property(prop, pref, required)
       end
@@ -30,6 +30,8 @@ module Prmd
       case
       when property_is_object?(property["type"])
         recurse_properties(Schema.new(property), "#{prefix}:", required)
+      when property_is_array_of_objects?(property)
+        recurse_properties(Schema.new(property["items"]), "#{prefix}:", required)
       else
         categorize_parameter(prefix, property, required)
       end
@@ -38,6 +40,12 @@ module Prmd
     def property_is_object?(type)
       return false unless type
       type == "object" || type.include?("object")
+    end
+
+    def property_is_array_of_objects?(property)
+      type = property["type"]
+      return false unless property && type
+      (type == "array" || type.include?("array")) && property["items"] && property_is_object?(property["items"]["type"])
     end
 
     def categorize_parameter(name, param,  required=false)

--- a/test/helpers.rb
+++ b/test/helpers.rb
@@ -177,4 +177,31 @@ module PrmdLinkTestHelpers
     }
 
   end
+
+  def link_required_array_of_objects_with_optional_property
+    {
+      "description"=>"Create users",
+      "href"=>"/users",
+      "method"=>"POST",
+      "rel"=>"create",
+      "schema"=> {
+        "properties"=>{
+          "users"=>{
+            "type"=>["array"],
+            "items" => {
+              "type" => ["object"],
+              "properties"=> {
+                "email"=>"string",
+                "name"=>"string"
+              },
+              "required" => ["email"]
+            }
+          }
+        },
+        "type"=>["object"],
+        "required" => ["users"]
+      },
+      "title"=>"Create"
+    }
+  end
 end

--- a/test/link_test.rb
+++ b/test/link_test.rb
@@ -12,8 +12,8 @@ module Prmd
       },
       {
         title: "parent_required",
-        optional: {},
-        required: {"user:email" => "string", "user:name" => "string"}
+        optional: {"user:email" => "string", "user:name" => "string"},
+        required: {}
       },
       {
         title: "child_required",
@@ -22,10 +22,15 @@ module Prmd
       },
       {
         title: "multiple_nested_required" ,
-        optional: {"user:name" => "string"},
-        required: {"user:email" => "string",
+        optional: {"user:name" => "string",
                    "address:street" => "string",
-                   "address:zip" => "string"}
+                   "address:zip" => "string"},
+        required: {"user:email" => "string"}
+      },
+      {
+        title: "required_array_of_objects_with_optional_property" ,
+        optional: {"users:name" => "string"},
+        required: {"users:email" => "string"}
       }
     ].each do |test_hash|
 


### PR DESCRIPTION
Even if the parent is required doesn't mean all the properties are required. (I've confirmed with some unit tests in WA that having a required parent doesn't require all the properties)

I'm also fixing the missing feature which allows you to have optional property of an object from an array of objects which the array is required.

```json
{
  "applicants": [
    {
      "applicant_cas_id": "123",
      "redirect_eligible": true
    },
    {
      "applicant_cas_id": "456"
    }
  ]
}
```

The previous JSON is an example of how our JSON looks like and our json-schema is validation it properly but the documentation wasn't generating properly with this PR we're fixing that issue.